### PR TITLE
Potential fix for code scanning alert no. 53: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,4 +1,6 @@
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/tjboldt/ProDOS-Utilities/security/code-scanning/53](https://github.com/tjboldt/ProDOS-Utilities/security/code-scanning/53)

To fix this problem, we need to declare a `permissions` block either at the workflow (root) level or at the job (in this case, the `build` job) level. Based on the actions and steps present, only the `contents: read` permission is required: both `actions/checkout` and `actions/setup-go` only need read access. To minimize privilege, we'll set `permissions: contents: read` at the root level, before the `jobs:` block; this will apply to all jobs unless overridden later. The change should be made by inserting the `permissions` block after the `name` property and before `on:` (as early as possible, per YAML style and GitHub's recommendations).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
